### PR TITLE
`Database#getLineComment` mustn't throw an exception

### DIFF
--- a/src/main/java/liquibase/nosql/database/AbstractNoSqlDatabase.java
+++ b/src/main/java/liquibase/nosql/database/AbstractNoSqlDatabase.java
@@ -72,7 +72,7 @@ public abstract class AbstractNoSqlDatabase extends AbstractJdbcDatabase impleme
 
     @Override
     public String getLineComment() {
-        throw new UnsupportedOperationException();
+        return "";
     }
 
     @Override


### PR DESCRIPTION
this was a last-minute change before merging PR #25 and we didn't spot this: all tests are failing due to this as this is being called by the constructor of `ChangeLogParameters`.

instead of returning something artifical (like `//`) which doesn't apply here we'll just return an empty string. this is needed until liquibase adds first-class support for NoSQL DBs and removes any SQL-specific features (requires liquibase/liquibase#4236).