### PR TITLE
tests: wait for index refresh before getting document count

### DIFF
--- a/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
@@ -70,6 +70,7 @@ public abstract class AbstractOpenSearchLiquibaseIT {
     }
 
     protected long getDocumentCount(final String indexName, final Query query) throws Exception {
+        this.getOpenSearchClient().indices().refresh(r -> r.index(indexName));
         final var request = new CountRequest.Builder()
                 .index(indexName)
                 .query(query)


### PR DESCRIPTION
i've several times observed flaky tests which seem to boil down to the fact that the index hadn't been refreshed yet before we queried the count.

this happens because writing a document does not make it immediately available for querying, unless you specify the `refresh=true` parameter in the request.

thus there were now two ways of fixing this:
* add `refresh=true` in the migrations
* execute an index refresh before querying the count

as the test files might be used as templates by other users i decided to go for the second approach, as this way the executions run faster (not relevant if you add a single document, but very relevant when you do larger migrations).
as we currently only rely on index creation (no refresh needed) and document count (the modified function) there's only a single place which had to be extended with this. if we ever add tests which use other metrics relying on the content of an index we'll have to add the same there.