### PR TITLE
use testcontainers' `@Container` annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.20.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.opensearch</groupId>
             <artifactId>opensearch-testcontainers</artifactId>
             <version>2.1.1</version>

--- a/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
@@ -3,7 +3,6 @@ package liquibase.ext.opensearch;
 import liquibase.command.CommandScope;
 import liquibase.command.core.UpdateCommandStep;
 import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
-import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
 import liquibase.database.DatabaseFactory;
 import liquibase.ext.opensearch.database.OpenSearchConnection;
 import liquibase.ext.opensearch.database.OpenSearchLiquibaseDatabase;
@@ -16,25 +15,21 @@ import org.opensearch.client.opensearch.core.CountRequest;
 import org.opensearch.client.opensearch.indices.ExistsRequest;
 import org.opensearch.testcontainers.OpensearchContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Testcontainers
 public abstract class AbstractOpenSearchLiquibaseIT {
-    final static OpensearchContainer<?> container;
-
     protected OpenSearchLiquibaseDatabase database;
     private OpenSearchConnection connection;
 
-    static {
-        container = new OpensearchContainer<>(DockerImageName
-                .parse("opensearchproject/opensearch:2.16.0")
-        )
-                .waitingFor(Wait.forHttp("/").forPort(9200))
-                .withStartupTimeout(Duration.ofSeconds(120));
-        container.start();
-    }
+    @Container
+    public OpensearchContainer<?> container = new OpensearchContainer<>(DockerImageName.parse("opensearchproject/opensearch:2.18.0"));
+
 
     @SneakyThrows
     @BeforeEach


### PR DESCRIPTION
so far we started the testcontainer manually. however, [the official way][quickstart] is to use the `@Testcontainers` and `@Container` annotations.

the major difference in behaviour between the two is that in our existing setup we started one container for all tests together, so they could influence each other, while the new setup launches a new container for each test. the downside of this is that test execution now takes longer as it always needs to spin up a new container and wait for OpenSearch to start. as we don't have that many tests this should be acceptable and the improved stability is probably worth it.

[quickstart]: https://java.testcontainers.org/quickstart/junit_5_quickstart/