### PR TITLE
prepare for first release: add missing features & documentation and clean up code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,99 @@
-# liquibase-opensearch
+# Liquibase Extension for OpenSearch
 
-Liquibase extension for OpenSearch
+This [Liquibase] extension supports managing migrations for [OpenSearch].
 
+> [!TIP]
+> If you wish to use Spring Boot you should be using [`liquibase-opensearch-spring-boot-starter`] instead of using this directly.
+
+## Usage
+This supports a single liquibase change type called `httpRequest` which executes the given request against OpenSearch.
+A simple example changelog might look like this:
+```yaml
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: test
+      comment: this creates the index testindex and stores a document in it
+      changes:
+        - httpRequest:
+            method: PUT
+            path: /testindex
+            body: >
+              {
+                "mappings": {
+                  "properties": {
+                    "testfield": {
+                      "type": "text"
+                    }
+                  }
+                }
+              }
+        - httpRequest:
+            method: PUT
+            path: /testindex/_doc/testdoc
+            body: >
+              {
+                "testfield": "foo"
+              }
+```
+
+### OpenSearch Connection
+
+#### New Connection From Liquibase
+
+The standard liquibase integration supports only connections with either HTTP or HTTPS with valid TLS certificates and
+either no authentication or basic authentication (username/password). To use this you have to prepend the URL(s) of
+OpenSearch with `opensearch:` so that Liquibase can identify it as an OpenSearch connection:
+```java
+void main() {
+    final var url = "opensearch:http://localhost:9200";
+    final var username = "...";
+    final var password = "...";
+
+    final var changeLogFile = "path/to/changelog.yaml";
+
+    // let Liquibase instantiate the connection
+    final var database = (OpenSearchLiquibaseDatabase) DatabaseFactory.getInstance().openDatabase(url, username, password, null, null);
+
+    // execute the migration
+    new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database)
+            .addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
+            .execute();
+}
+```
+
+This also supports multiple URLs for OpenSearch
+
+#### Custom `OpenSearchClient`
+
+If you wish to use any other form of authentication
+or have special requirements for the connection (e.g. not validate the TLS certificates) you have to [construct your own
+`OpenSearchClient`][custom-client] and pass that to `OpenSearchConnection`. See [CustomOpenSearchClientLiquibaseIT] for a full example.
+
+```java
+void main() {
+    final var changeLogFile = "path/to/changelog.yaml";
+
+    final var connection = new OpenSearchConnection(openSearchClient);
+    ConnectionServiceFactory.getInstance().register(connection);
+    final var database = new OpenSearchLiquibaseDatabase(connection);
+    DatabaseFactory.getInstance().register(database);
+
+    // execute the migration
+    new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database)
+            .addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
+            .execute();
+}
+```
+
+## License
+This project is licensed under the Apache License Version 2.0 - see the [LICENSE] file for details.
+
+[Liquibase]: https://www.liquibase.com/
+[OpenSearch]: https://opensearch.org/
+[`liquibase-opensearch-spring-boot-starter`]: https://github.com/liquibase/liquibase-opensearch-springboot-starter/
+[custom-client]: https://docs.opensearch.org/docs/latest/clients/java/
+[CustomOpenSearchClientLiquibaseIT]: src/test/java/liquibase/ext/opensearch/CustomOpenSearchClientLiquibaseIT.java
+[LICENSE]: LICENSE

--- a/src/main/java/liquibase/ext/opensearch/database/OpenSearchConnection.java
+++ b/src/main/java/liquibase/ext/opensearch/database/OpenSearchConnection.java
@@ -12,6 +12,7 @@ import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.TrustAllStrategy;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.reactor.ssl.TlsDetails;
@@ -165,18 +166,7 @@ public class OpenSearchConnection extends AbstractNoSqlConnection {
                         throw new RuntimeException("password provided but username not set!");
                     }
 
-                    final SSLContext sslcontext;
-                    try {
-                        sslcontext = SSLContextBuilder
-                                .create()
-                                .loadTrustMaterial(null, (chains, authType) -> true)
-                                .build();
-                    } catch (final NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
-                        throw new RuntimeException(e);
-                    }
-
                     final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
-                            .setSslContext(sslcontext)
                             // disable the certificate since our testing cluster just uses the default security configuration
                             .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                             // See https://issues.apache.org/jira/browse/HTTPCLIENT-2219

--- a/src/main/java/liquibase/ext/opensearch/database/OpenSearchConnection.java
+++ b/src/main/java/liquibase/ext/opensearch/database/OpenSearchConnection.java
@@ -153,7 +153,6 @@ public class OpenSearchConnection extends AbstractNoSqlConnection {
         final var transport = ApacheHttpClient5TransportBuilder
                 .builder(hostsArray)
                 .setHttpClientConfigCallback(httpClientBuilder -> {
-                    // TODO: support other credential providers
                     final var username = this.connectionProperties.flatMap(p -> Optional.ofNullable(p.getProperty("user")));
                     final var password = this.connectionProperties.flatMap(p -> Optional.ofNullable(p.getProperty("password")));
 

--- a/src/main/java/liquibase/ext/opensearch/database/OpenSearchLiquibaseDatabase.java
+++ b/src/main/java/liquibase/ext/opensearch/database/OpenSearchLiquibaseDatabase.java
@@ -12,6 +12,11 @@ public class OpenSearchLiquibaseDatabase extends AbstractNoSqlDatabase {
     public static final String OPENSEARCH_PREFIX = PRODUCT_SHORT_NAME + ":";
     public static final String OPENSEARCH_URI_SEPARATOR = ",";
 
+    public OpenSearchLiquibaseDatabase(final OpenSearchConnection openSearchConnection) {
+        super();
+        this.setConnection(openSearchConnection);
+    }
+
     @Override
     public void dropDatabaseObjects(final CatalogAndSchema schemaToDrop) throws LiquibaseException {
         throw new UnsupportedOperationException();

--- a/src/main/java/liquibase/nosql/database/AbstractNoSqlConnection.java
+++ b/src/main/java/liquibase/nosql/database/AbstractNoSqlConnection.java
@@ -42,15 +42,15 @@ public abstract class AbstractNoSqlConnection implements DatabaseConnection {
 
     @Override
     public boolean getAutoCommit() throws DatabaseException {
-        // TODO: this is not applicable (OpenSearch doesn't support transactions) but this gets called from
-        //  `#setConnection`, thus we can't just throw an exception.
+        // this is not applicable (OpenSearch doesn't support transactions) but this gets called from
+        // `#setConnection`, thus we can't just throw an exception.
         return false;
     }
 
     @Override
     public void setAutoCommit(boolean autoCommit) throws DatabaseException {
-        // TODO: this is not applicable (OpenSearch doesn't support transactions) but this gets called from
-        //  `#setConnection`, thus we can't just throw an exception.
+        // this is not applicable (OpenSearch doesn't support transactions) but this gets called from
+        // `#setConnection`, thus we can't just throw an exception.
     }
 
     @Override

--- a/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
@@ -14,12 +14,9 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.CountRequest;
 import org.opensearch.client.opensearch.indices.ExistsRequest;
 import org.opensearch.testcontainers.OpensearchContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-
-import java.time.Duration;
 
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 @Testcontainers
@@ -30,8 +27,15 @@ public abstract class AbstractOpenSearchLiquibaseIT {
     protected static final String OPENSEARCH_DOCKER_IMAGE_NAME = "opensearchproject/opensearch:2.18.0";
 
     @Container
-    protected OpensearchContainer<?> container = new OpensearchContainer<>(DockerImageName.parse(OPENSEARCH_DOCKER_IMAGE_NAME));
+    protected OpensearchContainer<?> container = newContainer();
 
+    /**
+     * This allows tests to define alternative containers, e.g. enabling security.
+     * @return the testcontainer to be used for this test.
+     */
+    protected OpensearchContainer<?> newContainer() {
+        return new OpensearchContainer<>(DockerImageName.parse(OPENSEARCH_DOCKER_IMAGE_NAME));
+    }
 
     @SneakyThrows
     @BeforeEach

--- a/src/test/java/liquibase/ext/opensearch/CustomOpenSearchClientLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/CustomOpenSearchClientLiquibaseIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.opensearch.testcontainers.OpensearchContainer;
 
 import javax.net.ssl.SSLContext;
 import java.security.KeyManagementException;
@@ -32,6 +33,11 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CustomOpenSearchClientLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
+
+    @Override
+    protected OpensearchContainer<?> newContainer() {
+        return super.newContainer().withSecurityEnabled();
+    }
 
     @SneakyThrows
     private OpenSearchClient newOpenSearchClientFromContainer() {

--- a/src/test/java/liquibase/ext/opensearch/CustomOpenSearchClientLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/CustomOpenSearchClientLiquibaseIT.java
@@ -1,0 +1,107 @@
+package liquibase.ext.opensearch;
+
+import liquibase.database.ConnectionServiceFactory;
+import liquibase.database.DatabaseFactory;
+import liquibase.ext.opensearch.database.OpenSearchConnection;
+import liquibase.ext.opensearch.database.OpenSearchLiquibaseDatabase;
+import lombok.SneakyThrows;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.TrustAllStrategy;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.reactor.ssl.TlsDetails;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CustomOpenSearchClientLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
+
+    @SneakyThrows
+    private OpenSearchClient newOpenSearchClientFromContainer() {
+        final var host = HttpHost.create(this.container.getHttpHostAddress());
+
+        final var transport = ApacheHttpClient5TransportBuilder
+                .builder(host)
+                .setHttpClientConfigCallback(httpClientBuilder -> {
+                    final var username = Optional.ofNullable(this.container.getUsername());
+                    final var password = Optional.ofNullable(this.container.getPassword());
+
+                    if (username.isPresent()) {
+                        final var credentialsProvider = new BasicCredentialsProvider();
+                        final var credentials = new UsernamePasswordCredentials(username.get(), password.orElse("").toCharArray());
+                        credentialsProvider.setCredentials(new AuthScope(host), credentials);
+                        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    } else if (password.isPresent()) {
+                        throw new RuntimeException("password provided but username not set!");
+                    }
+
+                    final SSLContext sslcontext;
+                    try {
+                        sslcontext = SSLContextBuilder
+                                .create()
+                                .loadTrustMaterial(null, new TrustAllStrategy())
+                                .build();
+                    } catch (final NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
+                            .setSslContext(sslcontext)
+                            // disable the certificate since our testing cluster just uses the default security configuration
+                            .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                            // See https://issues.apache.org/jira/browse/HTTPCLIENT-2219
+                            .setTlsDetailsFactory(sslEngine -> new TlsDetails(sslEngine.getSession(), sslEngine.getApplicationProtocol()))
+                            .build();
+
+                    final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
+                            .setTlsStrategy(tlsStrategy)
+                            .build();
+
+                    return httpClientBuilder
+                            .setConnectionManager(connectionManager);
+                })
+                .setMapper(new JacksonJsonpMapper())
+                .build();
+
+        return new OpenSearchClient(transport);
+    }
+
+    @SneakyThrows
+    @BeforeEach
+    @Override
+    protected void beforeEach() {
+        // we want to use our own connection (e.g. because we have requirements which are not fulfilled by the standard
+        // client constructed by liquibase).
+        // => do not rely on liquibase' standard mechanism of constructing a new connection, instead we force it to take our own.
+        this.connection = new OpenSearchConnection(this.newOpenSearchClientFromContainer());
+        ConnectionServiceFactory.getInstance().register(this.connection);
+        this.database = new OpenSearchLiquibaseDatabase(this.connection);
+        DatabaseFactory.getInstance().register(this.database);
+    }
+
+    @SneakyThrows
+    @Test
+    void itCreatesTheChangelogAndLockIndices() {
+        this.doLiquibaseUpdate("liquibase/ext/changelog.empty.yaml");
+        assertThat(this.indexExists(this.database.getDatabaseChangeLogLockTableName())).isTrue();
+        assertThat(this.indexExists(this.database.getDatabaseChangeLogTableName())).isTrue();
+    }
+
+}

--- a/src/test/java/liquibase/ext/opensearch/MultipleOpenSearchNodesLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/MultipleOpenSearchNodesLiquibaseIT.java
@@ -17,10 +17,10 @@ class MultipleOpenSearchNodesLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
         // if we launch two testcontainers they can't see each other and thus don't form a cluster => just use the same URL twice to show that it's being accepted
         // note: don't use the constants here to detect if we ever change them (to make sure that we actively decide on doing a breaking change rather than making it by mistake).
         final String url = "opensearch:" + this.container.getHttpHostAddress() + "," + this.container.getHttpHostAddress();
-        final String username = container.getUsername();
-        final String password = container.getPassword();
-        database = (OpenSearchLiquibaseDatabase) DatabaseFactory.getInstance().openDatabase(url, username, password, null, null);
-        connection = (OpenSearchConnection) this.database.getConnection();
+        final String username = this.container.getUsername();
+        final String password = this.container.getPassword();
+        this.database = (OpenSearchLiquibaseDatabase) DatabaseFactory.getInstance().openDatabase(url, username, password, null, null);
+        this.connection = (OpenSearchConnection) this.database.getConnection();
     }
 
     @SneakyThrows

--- a/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
@@ -2,9 +2,7 @@ package liquibase.ext.opensearch;
 
 import liquibase.command.CommandScope;
 import liquibase.command.core.ClearChecksumsCommandStep;
-import liquibase.command.core.UpdateCommandStep;
 import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
-import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -21,6 +19,11 @@ public class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
     public void openSearchIsRunning() {
         assertThat(this.getOpenSearchClient().info().clusterName()).isEqualTo("docker-cluster");
         assertThat(this.database.getDatabaseMajorVersion()).isEqualTo(2);
+    }
+
+    @Test
+    public void connectionReturnsClusterNameAsUrl() {
+        assertThat(this.connection.getURL()).isEqualTo("docker-cluster");
     }
 
     @SneakyThrows

--- a/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
@@ -2,10 +2,13 @@ package liquibase.ext.opensearch;
 
 import liquibase.command.CommandScope;
 import liquibase.command.core.ClearChecksumsCommandStep;
+import liquibase.command.core.TagCommandStep;
 import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.CountRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -83,6 +86,38 @@ public class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
 
         final var countAfterClear = this.getDocumentCount("databasechangelog", new Query.Builder().exists(e -> e.field("lastCheckSum")).build());
         assertThat(countAfterClear).isZero();
+    }
+
+    @SneakyThrows
+    @Test
+    public void itCanTagEntries() {
+        this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.multiple-steps.yaml");
+
+        final var countBeforeTag = this.getDocumentCount("databasechangelog", new Query.Builder().exists(e -> e.field("tag")).build());
+        assertThat(countBeforeTag).isZero();
+
+        new CommandScope("tag") // TODO: use TagCommandStep.COMMAND_NAME once https://github.com/liquibase/liquibase/pull/6932 is merged & released
+                .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, this.database)
+                .addArgumentValue(TagCommandStep.TAG_ARG, "testTag")
+                .execute();
+
+        // ensure that we have exactly one tag set
+        final var countAfterTag = this.getDocumentCount("databasechangelog", new Query.Builder()
+                .match(m -> m.field("tag").query(v -> v.stringValue("testTag"))).build());
+        assertThat(countAfterTag).isEqualTo(1);
+
+        // we know that ID=4001 is the last, so it must be this one which has been tagged
+        final var countAfterTagWithId4001 = this.getDocumentCount("databasechangelog", new Query.Builder()
+                .bool(
+                        b -> b.must(
+                                new Query.Builder().match(
+                                        m -> m.field("tag").query(v -> v.stringValue("testTag"))
+                                ).build(),
+                                new Query.Builder().ids(
+                                        i -> i.values("4001")
+                                ).build()
+                        )).build());
+        assertThat(countAfterTagWithId4001).isEqualTo(1);
     }
 
 }

--- a/src/test/resources/liquibase/ext/changelog.httprequest.multiple-steps.yaml
+++ b/src/test/resources/liquibase/ext/changelog.httprequest.multiple-steps.yaml
@@ -1,0 +1,35 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4000
+      author: test
+      labels: httpRequestLabel
+      context: httpRequestContext
+      comment: httpRequestComment
+      changes:
+        - httpRequest:
+            method: PUT
+            path: /testindex-always
+            body: >
+              {
+                "mappings": {
+                  "properties": {
+                    "testfield": {
+                      "type": "text"
+                    }
+                  }
+                }
+              }
+  - changeSet:
+      id: 4001
+      author: test
+      labels: httpRequestLabel
+      context: httpRequestContext
+      comment: httpRequestComment
+      changes:
+        - httpRequest:
+            method: POST
+            path: /testindex-always/_doc
+            body: >
+              {
+                "testfield": "test"
+              }


### PR DESCRIPTION
see the individual commit messages for further details.
it's easiest to review them commit-by-commit.

this should be enough to get a v0.0.1 (or v0.1.0?) out of the door so that we can pull it in in `liquibase-opensearch-spring-boot-starter`.