### PR TITLE
Fix reusable workflow permissions (DAT-20361)

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -5,6 +5,12 @@ on:
     types:
       - closed
 
+permissions:
+  contents: write
+  actions: read
+  packages: write
+  id-token: write
+
 jobs:
   attach-artifact-to-release:
     uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,6 +6,13 @@ on:
       - main
       - master
 
+permissions:
+  contents: write
+  pull-requests: read
+  issues: read
+  statuses: read
+  actions: read
+
 jobs:
   create-release:
     uses: liquibase/build-logic/.github/workflows/create-release.yml@main

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -5,6 +5,12 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+  id-token: write
+
 jobs:
   release:
     uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main


### PR DESCRIPTION
## Summary
- Fix permissions in workflows that call reusable workflows from build-logic repo
- Add required permissions to attach-artifact-release.yml, release-published.yml, and create-release.yml
- Ensures workflows have proper permissions to match the build-logic reusable workflows they call

## Test plan
- [ ] Verify workflow permissions match build-logic workflows
- [ ] Test workflow execution after merge

🤖 Generated with [Claude Code](https://claude.ai/code)