### PR TITLE
Fix create-release.yml permissions (DAT-20361)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,6 +12,8 @@ permissions:
   issues: read
   statuses: read
   actions: read
+  security-events: write
+  id-token: write
 
 jobs:
   create-release:


### PR DESCRIPTION
## Summary
- Add missing security-events: write and id-token: write permissions to create-release.yml
- Ensures workflow permissions match build-logic/create-release.yml requirements
- Resolves workflow permission validation errors

## Test plan
- [ ] Verify workflow permissions match build-logic requirements
- [ ] Test create-release workflow execution after merge

🤖 Generated with [Claude Code](https://claude.ai/code)