### PR TITLE
CI: run integration tests using the central workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,25 +28,9 @@ jobs:
     secrets: inherit
     with:
       java: "[ 17, 21 ]"
-
-  integration-tests:
-    name: Integration Test - Java ${{ matrix.java }}
-    runs-on: ubuntu-latest
-    needs: build-test
-    strategy:
-      matrix:
-        java: [17, 21]
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ matrix.java }}
-        distribution: 'adopt'
-    - name: Test With Maven
-      run: ./mvnw integration-test
+      runIntegrationTests: true
 
   dependabot:
-    needs: integration-tests
+    needs: build-test
     uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
     secrets: inherit


### PR DESCRIPTION
i've now introduced a new attribute for this on the central workflow, so we should use that instead. this way, the test results are also being picked up by Sonar.
see the PR for more details: https://github.com/liquibase/build-logic/pull/365