### PR TITLE
set `sdou` label on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - sdou
 
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - sdou
 


### PR DESCRIPTION
dependabot PRs always have a failed check because no label is set but there's a CI job which requires specific labels to be present.

`sdou` is the label standing for "Security, Driver and Other Updates", which is exactly what the dependabot PRs are.

fixes #34