### PR TITLE
update to `opensearch-testcontainers` 3.0.1

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -10,6 +10,8 @@ jobs:
   nightly-build:
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     with:
-      nightly: true
-      java: "[ 17, 21 ]"
+      # we support JDK 17, however opensearch-testcontainers used in the tests only supports JDK 21
+      javaBuildVersion: '17'
+      java: '21'
+      runIntegrationTests: true
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,9 @@ jobs:
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     secrets: inherit
     with:
-      java: "[ 17, 21 ]"
+      # we support JDK 17, however opensearch-testcontainers used in the tests only supports JDK 21
+      javaBuildVersion: '17'
+      java: '21'
       runIntegrationTests: true
 
   dependabot:

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.opensearch</groupId>
             <artifactId>opensearch-testcontainers</artifactId>
-            <version>2.1.3</version>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
@@ -13,7 +13,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.CountRequest;
 import org.opensearch.client.opensearch.indices.ExistsRequest;
-import org.opensearch.testcontainers.OpensearchContainer;
+import org.opensearch.testcontainers.OpenSearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -28,7 +28,7 @@ public abstract class AbstractOpenSearchLiquibaseIT {
     protected static final String OPENSEARCH_3_DOCKER_IMAGE_NAME = "opensearchproject/opensearch:3.0.0";
 
     @Container
-    protected OpensearchContainer<?> container = newContainer();
+    protected OpenSearchContainer<?> container = newContainer();
 
     /***
      * @return whether OpenSearch V2 or V3 should be used for the tests. Defaults to using OpenSearch 3.x.
@@ -41,8 +41,8 @@ public abstract class AbstractOpenSearchLiquibaseIT {
      * This allows tests to define alternative containers, e.g. enabling security.
      * @return the testcontainer to be used for this test.
      */
-    protected OpensearchContainer<?> newContainer() {
-        return new OpensearchContainer<>(DockerImageName.parse(
+    protected OpenSearchContainer<?> newContainer() {
+        return new OpenSearchContainer<>(DockerImageName.parse(
                 this.openSearchImageName()
         ));
     }

--- a/src/test/java/liquibase/ext/opensearch/CustomOpenSearchClientLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/CustomOpenSearchClientLiquibaseIT.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
-import org.opensearch.testcontainers.OpensearchContainer;
+import org.opensearch.testcontainers.OpenSearchContainer;
 
 import javax.net.ssl.SSLContext;
 import java.security.KeyManagementException;
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CustomOpenSearchClientLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
 
     @Override
-    protected OpensearchContainer<?> newContainer() {
+    protected OpenSearchContainer<?> newContainer() {
         return super.newContainer().withSecurityEnabled();
     }
 


### PR DESCRIPTION
this contains two breaking changes in that library:
- they renamed `OpensearchContainer` to `OpenSearchContainer`
- they increased the minimum supported java version to 21

for us this is not a breaking change as it is purely a test dependency and has no impact on our public API. we continue to support java 17, however we can now only run our tests on java 21.

also the nightly build now also runs integration tests.