### PR TITLE
fix release date of v0.1.0 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-## [0.1.0] - 2025-08-18
+## [0.1.0] - 2025-08-25
 
 ### Changed
 


### PR DESCRIPTION
the release hasn't happened yet but should be triggered today.