### PR TITLE
fix changeset ID handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Changesets are only unique in the changelog filename + `id` + `author` combination, but so far `liquibase-opensearch`
+  considered them unique by just their `id`. New changesets are now stored with the correct combination as their ID.
+
 ## [0.2.0] - 2026-03-09
 
 ### Added

--- a/src/main/java/liquibase/ext/opensearch/changelog/OpenSearchHistoryService.java
+++ b/src/main/java/liquibase/ext/opensearch/changelog/OpenSearchHistoryService.java
@@ -146,7 +146,7 @@ public class OpenSearchHistoryService extends AbstractNoSqlHistoryService<OpenSe
         try {
             this.getOpenSearchClient()
                     .index(r -> r.index(this.getDatabaseChangeLogTableName())
-                            .id(ranChangeSet.getId())
+                            .id(ranChangeSet.toString())
                             .document(ranChangeSet)
                             .refresh(Refresh.WaitFor));
         } catch (final IOException e) {
@@ -159,7 +159,7 @@ public class OpenSearchHistoryService extends AbstractNoSqlHistoryService<OpenSe
         try {
             this.getOpenSearchClient()
                     .delete(r -> r.index(this.getDatabaseChangeLogTableName())
-                            .id(String.valueOf(changeSet.getId()))
+                            .id(changeSet.toString())
                             .refresh(Refresh.WaitFor));
         } catch (final IOException e) {
             throw new DatabaseException(e);
@@ -209,11 +209,13 @@ public class OpenSearchHistoryService extends AbstractNoSqlHistoryService<OpenSe
             );
 
             if (response.hits().total().value() == 0) {
-                getLogger().warning("tried to add a tag but found no entries in the changelog table!");
+                getLogger().warning("tried to add a tag (%s) but found no entries in the changelog table!".formatted(tagString));
                 return;
             }
 
             final var entryToTag = response.hits().hits().get(0).id();
+
+            getLogger().fine("tagging entry %s as %s".formatted(entryToTag, tagString));
 
             this.getOpenSearchClient().updateByQuery(
                     u -> u
@@ -248,8 +250,9 @@ public class OpenSearchHistoryService extends AbstractNoSqlHistoryService<OpenSe
 
         try {
             this.getOpenSearchClient()
-                    .update(r -> r.index(this.getDatabaseChangeLogTableName())
-                                    .id(changeSet.getId())
+                    .update(r -> r
+                                    .index(this.getDatabaseChangeLogTableName())
+                                    .id(changeSet.toString())
                                     .doc(new CheckSumObj(checkSum))
                                     .refresh(Refresh.WaitFor)
                             , RanChangeSet.class);

--- a/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/AbstractOpenSearchLiquibaseIT.java
@@ -1,5 +1,6 @@
 package liquibase.ext.opensearch;
 
+import liquibase.command.CommandResults;
 import liquibase.command.CommandScope;
 import liquibase.command.core.UpdateCommandStep;
 import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
@@ -61,16 +62,16 @@ public abstract class AbstractOpenSearchLiquibaseIT {
         return this.connection.getOpenSearchClient();
     }
 
-    protected void doLiquibaseUpdate(final String changeLogFile, final String contexts) throws Exception {
-        new CommandScope(UpdateCommandStep.COMMAND_NAME)
+    protected CommandResults doLiquibaseUpdate(final String changeLogFile, final String contexts) throws Exception {
+        return new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, this.database)
                 .addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
                 .addArgumentValue(UpdateCommandStep.CONTEXTS_ARG, contexts)
                 .execute();
     }
 
-    protected void doLiquibaseUpdate(final String changeLogFile) throws Exception {
-        this.doLiquibaseUpdate(changeLogFile, "");
+    protected CommandResults doLiquibaseUpdate(final String changeLogFile) throws Exception {
+        return this.doLiquibaseUpdate(changeLogFile, "");
     }
 
     protected boolean indexExists(final String indexName) throws Exception {

--- a/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
@@ -1,5 +1,8 @@
 package liquibase.ext.opensearch;
 
+import liquibase.change.CheckSum;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.RanChangeSet;
 import liquibase.command.CommandScope;
 import liquibase.command.core.ClearChecksumsCommandStep;
 import liquibase.command.core.TagCommandStep;
@@ -8,7 +11,10 @@ import liquibase.report.ChangesetInfo;
 import liquibase.report.UpdateReportParameters;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,15 +56,55 @@ class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
         assertThat(this.indexExists("xmltestindex")).isTrue();
     }
 
+    /**
+     * Up to and including version 0.2.0 we stored only the `id` as the ID of a document instead of path+id+author.
+     * This test ensures that we still match old entries and don't re-run them.
+     */
+    @SneakyThrows
+    @Test
+    void itSkipsPreviouslyExecutedChangelogEntries() {
+        // first run an empty changelog so that liquibase sets up the changelog index
+        this.doLiquibaseUpdate("liquibase/ext/changelog.empty.yaml");
+
+        // then simulate that this ran with an earlier version (with the old ID handling)
+        final var ranChangeSet = new RanChangeSet("liquibase/ext/changelog.httprequest.yaml", "1", "test", CheckSum.parse("9:8f8ad33ca7428632a913f3295bb18900"), new Date(), "", ChangeSet.ExecType.EXECUTED, "httpRequest path=/testindex", "httpRequestComment", null, null, "");
+        this.getOpenSearchClient()
+                .index(r -> r.index("databasechangelog")
+                        .id(ranChangeSet.getId()) // use getId instead of toString to simulate old behaviour
+                        .document(ranChangeSet)
+                        .refresh(Refresh.WaitFor));
+
+        // now run the changelog - the index is not supposed to be created
+        final var updateResult = this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.yaml");
+        assertThat(this.indexExists("testindex")).isFalse();
+        final var updateReport = ((UpdateReportParameters) updateResult.getResult("updateReport")).getChangesetInfo();
+        assertThat(updateReport.getChangesetCount()).isEqualTo(0);
+    }
+
     @SneakyThrows
     @Test
     void itSkipsExecutedChangelogEntries() {
         // run it the first time (expected to execute it)
-        this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.yaml");
+        this.doLiquibaseUpdate("liquibase/ext/changelog.id-handling.yaml");
         assertThat(this.indexExists("testindex")).isTrue();
+        assertThat(this.indexExists("testindex2")).isTrue();
         // run it a second time (expected to succeed and not re-run the script again)
-        final var updateResult = this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.yaml");
-        final var updateReport = (ChangesetInfo) updateResult.getResult("updateReport");
+        final var updateResult = this.doLiquibaseUpdate("liquibase/ext/changelog.id-handling.yaml");
+        final var updateReport = ((UpdateReportParameters) updateResult.getResult("updateReport")).getChangesetInfo();
+        assertThat(updateReport.getChangesetCount()).isEqualTo(0);
+    }
+
+    @SneakyThrows
+    @Test
+    void itHandlesChangelogsWithIncludes() {
+        // run it the first time (expected to execute it)
+        this.doLiquibaseUpdate("liquibase/ext/changelog.multi-include.yaml");
+        assertThat(this.indexExists("testindex")).isTrue();
+        assertThat(this.indexExists("testindex1")).isTrue();
+        assertThat(this.indexExists("testindex2")).isTrue();
+        // run it a second time (expected to succeed and not re-run the script again)
+        final var updateResult = this.doLiquibaseUpdate("liquibase/ext/changelog.multi-include.yaml");
+        final var updateReport = ((UpdateReportParameters) updateResult.getResult("updateReport")).getChangesetInfo();
         assertThat(updateReport.getChangesetCount()).isEqualTo(0);
     }
 
@@ -117,8 +163,8 @@ class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
                 q.match(m -> m.field("tag").query(v -> v.stringValue("testTag")))));
         assertThat(countAfterTag).isEqualTo(1);
 
-        // we know that ID=4001 is the last, so it must be this one which has been tagged
-        final var countAfterTagWithId4001 = this.getDocumentCount("databasechangelog", Query.of(q ->
+        // we know that ID=2 is the last, so it must be this one which has been tagged
+        final var countAfterTagWithId2 = this.getDocumentCount("databasechangelog", Query.of(q ->
                 q.bool(b ->
                     b.must(
                         m -> m.match(
@@ -126,12 +172,12 @@ class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
                         )
                     )
                     .must(
-                        m -> m.ids(
-                            i -> i.values("4001")
+                        m -> m.match(
+                            ma -> ma.field("id").query(v -> v.stringValue("2"))
                         )
                     )
                 )));
-        assertThat(countAfterTagWithId4001).isEqualTo(1);
+        assertThat(countAfterTagWithId2).isEqualTo(1);
     }
 
 }

--- a/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
@@ -4,6 +4,8 @@ import liquibase.command.CommandScope;
 import liquibase.command.core.ClearChecksumsCommandStep;
 import liquibase.command.core.TagCommandStep;
 import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
+import liquibase.report.ChangesetInfo;
+import liquibase.report.UpdateReportParameters;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -46,6 +48,18 @@ class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
     void itExecutesAHttpRequestAndCreatesTheIndexWithXMLChangelog() {
         this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.xml");
         assertThat(this.indexExists("xmltestindex")).isTrue();
+    }
+
+    @SneakyThrows
+    @Test
+    void itSkipsExecutedChangelogEntries() {
+        // run it the first time (expected to execute it)
+        this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.yaml");
+        assertThat(this.indexExists("testindex")).isTrue();
+        // run it a second time (expected to succeed and not re-run the script again)
+        final var updateResult = this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.yaml");
+        final var updateReport = (ChangesetInfo) updateResult.getResult("updateReport");
+        assertThat(updateReport.getChangesetCount()).isEqualTo(0);
     }
 
     @SneakyThrows

--- a/src/test/resources/liquibase/ext/changelog.httprequest.always.yaml
+++ b/src/test/resources/liquibase/ext/changelog.httprequest.always.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: 3000
+      id: 1
       author: test
       labels: httpRequestLabel
       context: httpRequestContext
@@ -20,7 +20,7 @@ databaseChangeLog:
                 }
               }
   - changeSet:
-      id: 3001
+      id: 2
       author: test
       labels: httpRequestLabel
       context: httpRequestContext

--- a/src/test/resources/liquibase/ext/changelog.httprequest.multiple-steps.yaml
+++ b/src/test/resources/liquibase/ext/changelog.httprequest.multiple-steps.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: 4000
+      id: 1
       author: test
       labels: httpRequestLabel
       context: httpRequestContext
@@ -20,7 +20,7 @@ databaseChangeLog:
                 }
               }
   - changeSet:
-      id: 4001
+      id: 2
       author: test
       labels: httpRequestLabel
       context: httpRequestContext

--- a/src/test/resources/liquibase/ext/changelog.httprequest.xml
+++ b/src/test/resources/liquibase/ext/changelog.httprequest.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd
         http://www.liquibase.org/xml/ns/opensearch http://www.liquibase.org/xml/ns/opensearch/liquibase-opensearch-1.0.xsd">
 
-    <changeSet id="10000" author="test" labels="XMLhttpRequestLabel" context="httpRequestContext">
+    <changeSet id="1" author="test" labels="XMLhttpRequestLabel" context="httpRequestContext">
         <comment>httpRequestComment</comment>
         <opensearch:httpRequest>
             <opensearch:method>PUT</opensearch:method>

--- a/src/test/resources/liquibase/ext/changelog.httprequest.yaml
+++ b/src/test/resources/liquibase/ext/changelog.httprequest.yaml
@@ -1,6 +1,6 @@
 databaseChangeLog:
   - changeSet:
-      id: 1000
+      id: 1
       author: test
       labels: httpRequestLabel
       context: httpRequestContext

--- a/src/test/resources/liquibase/ext/changelog.id-handling.yaml
+++ b/src/test/resources/liquibase/ext/changelog.id-handling.yaml
@@ -3,12 +3,12 @@ databaseChangeLog:
       id: 1
       author: test
       labels: httpRequestLabel
-      context: context1
+      context: httpRequestContext
       comment: httpRequestComment
       changes:
         - httpRequest:
             method: PUT
-            path: /testindex1
+            path: /testindex
             body: >
               {
                 "mappings": {
@@ -20,10 +20,10 @@ databaseChangeLog:
                 }
               }
   - changeSet:
-      id: 2
-      author: test
+      id: 1
+      author: other
       labels: httpRequestLabel
-      context: context2
+      context: httpRequestContext
       comment: httpRequestComment
       changes:
         - httpRequest:

--- a/src/test/resources/liquibase/ext/changelog.multi-include.yaml
+++ b/src/test/resources/liquibase/ext/changelog.multi-include.yaml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: "changelog.httprequest.yaml"
+  - include:
+      relativeToChangelogFile: true
+      file: "changelog.httprequest.contexts.yaml"


### PR DESCRIPTION
see the individual commit messages for further details. this solves an ugly bug where we so far handled the uniqueness of changesets wrongly.