### PR TITLE
support specifying the `Content-Type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* The `Content-Type` of the request can now be specified using the optional `contentType` field on `httpRequest`.
+  The default is `application/json`, but for bulk requests this has to be set to `application/x-ndjson`
+
 ### Fixed
 
 * Changesets are only unique in the changelog filename + `id` + `author` combination, but so far `liquibase-opensearch`

--- a/src/main/java/liquibase/ext/opensearch/change/HttpRequestChange.java
+++ b/src/main/java/liquibase/ext/opensearch/change/HttpRequestChange.java
@@ -9,6 +9,7 @@ import liquibase.statement.SqlStatement;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.hc.core5.http.ContentType;
 
 import java.util.Optional;
 
@@ -21,21 +22,23 @@ import java.util.Optional;
 public class HttpRequestChange extends AbstractChange {
 
     private String method;
+    private String contentType;
     private String path;
     private String body;
 
     @Override
     public String getConfirmationMessage() {
-        return String.format("executed the HTTP %s request against %s (with a body of size %d)",
+        return String.format("executed the HTTP %s request against %s (with a body of size %d and content type %s)",
                 this.getMethod(),
                 this.getPath(),
-                Optional.ofNullable(this.getBody()).map(String::length).orElse(0));
+                Optional.ofNullable(this.getBody()).map(String::length).orElse(0),
+                Optional.ofNullable(this.getContentType()).orElse(ContentType.APPLICATION_JSON.getMimeType()));
     }
 
     @Override
     public SqlStatement[] generateStatements(final Database database) {
         return new SqlStatement[] {
-            new HttpRequestStatement(this.getMethod(), this.getPath(), this.getBody())
+            new HttpRequestStatement(this.getMethod(), this.getContentType(), this.getPath(), this.getBody())
         };
     }
 }

--- a/src/main/java/liquibase/ext/opensearch/statement/HttpRequestStatement.java
+++ b/src/main/java/liquibase/ext/opensearch/statement/HttpRequestStatement.java
@@ -7,9 +7,11 @@ import liquibase.logging.Logger;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.apache.hc.core5.http.ContentType;
 import org.opensearch.client.opensearch.generic.Bodies;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient.ClientOptions;
 import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.transport.TransportOptions;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -22,22 +24,32 @@ public class HttpRequestStatement extends AbstractOpenSearchStatement implements
     private final Logger log = Scope.getCurrentScope().getLog(getClass());
 
     private String method;
+    private String contentType;
     private String path;
     private String body;
 
     @Override
     public String toString() {
-        return String.format("HTTP %s request against %s (with a body of size %d)",
+        return String.format("HTTP %s request against %s (with a body of size %d and content type %s)",
                 this.getMethod(),
                 this.getPath(),
-                Optional.ofNullable(this.getBody()).map(String::length).orElse(0));
+                Optional.ofNullable(this.getBody()).map(String::length).orElse(0),
+                Optional.ofNullable(this.getContentType()).orElse(ContentType.APPLICATION_JSON.getMimeType()));
     }
 
     @Override
     public void execute(final OpenSearchLiquibaseDatabase database) throws DatabaseException {
         log.info(this.toString());
 
-        final var httpClient = this.getOpenSearchClient(database).generic().withClientOptions(ClientOptions.throwOnHttpErrors());
+        final var transportOptionsBuilder = TransportOptions.builder();
+        if (this.contentType != null) {
+            transportOptionsBuilder.addHeader("Content-Type", this.getContentType());
+        }
+        final var transportOptions = transportOptionsBuilder.build();
+
+        final var httpClient = this.getOpenSearchClient(database).generic()
+                .withClientOptions(ClientOptions.throwOnHttpErrors())
+                .withTransportOptions(transportOptions);
 
         final var request = Requests.builder()
                 .endpoint(this.getPath())

--- a/src/main/resources/www.liquibase.org/xml/ns/opensearch/liquibase-opensearch-1.0.xsd
+++ b/src/main/resources/www.liquibase.org/xml/ns/opensearch/liquibase-opensearch-1.0.xsd
@@ -19,11 +19,12 @@
             <xsd:enumeration value="PATCH" />
         </xsd:restriction>
     </xsd:simpleType>
-    
+
     <xsd:element name="httpRequest">
         <xsd:complexType>
             <xsd:all>
                 <xsd:element name="method" type="httpMethods" />
+                <xsd:element name="contentType" type="xsd:string" minOccurs="0" />
                 <xsd:element name="path" type="xsd:string" />
                 <xsd:element name="body" type="xsd:string" />
             </xsd:all>

--- a/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
@@ -180,4 +180,12 @@ class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
         assertThat(countAfterTagWithId2).isEqualTo(1);
     }
 
+    @SneakyThrows
+    @Test
+    void itSupportsAlternativeContentTypes() {
+        this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.bulk.yaml");
+        assertThat(this.indexExists("testindex")).isTrue();
+        assertThat(this.getDocumentCount("testindex")).isEqualTo(2);
+    }
+
 }

--- a/src/test/resources/liquibase/ext/changelog.httprequest.bulk.yaml
+++ b/src/test/resources/liquibase/ext/changelog.httprequest.bulk.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: test
+      changes:
+        - httpRequest:
+            method: PUT
+            path: /testindex
+            body: >
+              {
+                "mappings": {
+                  "properties": {
+                    "testfield": {
+                      "type": "text"
+                    }
+                  }
+                }
+              }
+        - httpRequest:
+            method: POST
+            contentType: application/x-ndjson
+            path: /testindex/_bulk
+            body: |
+              { "create": {} }
+              { "testfield": "a" }
+              { "create": {} }
+              { "testfield": "b" }


### PR DESCRIPTION
for [bulk requests] the content type must be set to NDJSON (`Content-Type: application/x-ndjson`) rather than JSON (`application/json`).

as we do not know which endpoint needs which encoding and the generic client doesn't switch this automatically either we need to let the user specify this in the changelog.

i decided to define the field as a text field rather than using an enum in the XSD (as done for `httpMethod`) since i'm not 100% sure if there's a use-case where another content type is needed.

[bulk requests]: https://docs.opensearch.org/latest/api-reference/document-apis/bulk/