### PR TITLE
update to `liquibase-parent-pom:1.0.2`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent-pom</artifactId>
-        <version>0.6.0</version>
+        <version>1.0.2</version>
     </parent>
 
     <groupId>org.liquibase.ext</groupId>


### PR DESCRIPTION
this is also a pre-requisite for upgrading to Liquibase 5, however we can already do it now.