### PR TITLE
add test for unsupported change types

### DIFF
--- a/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
+++ b/src/test/java/liquibase/ext/opensearch/OpenSearchLiquibaseIT.java
@@ -7,7 +7,6 @@ import liquibase.command.CommandScope;
 import liquibase.command.core.ClearChecksumsCommandStep;
 import liquibase.command.core.TagCommandStep;
 import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
-import liquibase.report.ChangesetInfo;
 import liquibase.report.UpdateReportParameters;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -17,6 +16,7 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
 
@@ -186,6 +186,13 @@ class OpenSearchLiquibaseIT extends AbstractOpenSearchLiquibaseIT {
         this.doLiquibaseUpdate("liquibase/ext/changelog.httprequest.bulk.yaml");
         assertThat(this.indexExists("testindex")).isTrue();
         assertThat(this.getDocumentCount("testindex")).isEqualTo(2);
+    }
+
+    @Test
+    void itFailsOnUnsupportedChangeTypes() {
+        assertThatThrownBy(
+                () -> this.doLiquibaseUpdate("liquibase/ext/changelog.unsupported-changetype.yaml")
+        ).hasMessageContaining("Unknown type: liquibase.statement.core.CreateTableStatement");
     }
 
 }

--- a/src/test/resources/liquibase/ext/changelog.unsupported-changetype.yaml
+++ b/src/test/resources/liquibase/ext/changelog.unsupported-changetype.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: createTable-example
+      author: liquibase-docs
+      changes:
+        - createTable:
+            catalogName: department
+            columns:
+              - column:
+                  name: address
+                  type: varchar(255)
+            remarks: A String
+            schemaName: public
+            tableName: person
+            tablespace: A String


### PR DESCRIPTION
this ensures that Liquibase fails properly if the change type is not supported.
to be fair: this is a feature from liquibase-core, thus we shouldn't really be testing it here; but it's here for completeness since we claim that we don't support any other change type and we'd have done our registration wrong if we didn't fail on this.