### PR TITLE
TECHOPS-646: Pin step-level GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Validate PR Labels
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: minimum
           count: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,10 @@ jobs:
           - 9200:9200
           - 9600:9600
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
## 📋 Overview
Pins **step-level** `uses:` references to full-length commit SHAs, per the enterprise Actions SHA-pinning policy. Tracked in [TECHOPS-646](https://datical.atlassian.net/browse/TECHOPS-646) (relates to [TECHOPS-81](https://datical.atlassian.net/browse/TECHOPS-81)).

Step-level action references are enforced by **"Require actions to be pinned to a full-length commit SHA"**; job-level reusable-workflow refs (`*.yml@main`) are exempt. These refs were still pinned to tags/branches and would fail once enforcement is enabled.

## 🔧 Changes
- Replaced tag/branch refs with the resolved full commit SHA.
- Original ref preserved as a trailing `# <ref>` comment.
- Only active (non-commented) step-level references changed.

## ✅ Testing
- SHAs resolved via the GitHub API against current tag/branch HEAD.
- Post-change verification confirmed 0 remaining unpinned active step-level refs in the edited files.

## ⚠️ Notes
- No functional change: same action code, now immutably referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-646]: https://datical.atlassian.net/browse/TECHOPS-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-81]: https://datical.atlassian.net/browse/TECHOPS-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ