### PR TITLE
fix(ci): run extension tests on ubuntu only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
     secrets: inherit
     with:
       java: "[ 17, 21 ]"
+      # The integration tests start OpenSearch via testcontainers, which needs a
+      # Docker daemon. GitHub's windows-latest runners have none, so every IT
+      # errors with "Could not find a valid Docker environment" there.
+      os: '["ubuntu-latest"]'
       runIntegrationTests: true
 
   test-cli:


### PR DESCRIPTION
The integration tests start OpenSearch via testcontainers, which requires a Docker daemon. GitHub's `windows-latest` runners do not provide one, so every integration test errors there with:

```
Could not find a valid Docker environment
```

These failures were invisible until `build-logic` switched `os-extension-test.yml` from `mvn integration-test` to `mvn verify` ([07724fb](https://github.com/liquibase/build-logic/commit/07724fb), 2026-07-16). `integration-test` never runs `failsafe:verify`, so integration-test results were never enforced and the job reported success regardless of them. Every PR in this repo has been red since 2026-07-16; the last green run was 2026-07-13.

This pins the `os` matrix to `ubuntu-latest`.

`build-nightly.yml` is deliberately left untouched: it does not set `runIntegrationTests`, so it skips the integration tests and its Windows leg still passes.

### Note

This removes the 4 Windows jobs but does **not** make CI green on its own. Four genuine integration-test failures remain on Linux, tracked separately:

- `OpenSearchLiquibaseIT.itExecutesAHttpRequestAndCreatesTheIndexWithYAMLChangelog`
- `OpenSearchLiquibaseIT.itHandlesChangelogsWithIncludes`
- `OpenSearchLiquibaseIT.itSkipsExecutedChangelogEntries`
- `OpenSearchLiquibaseIT.itCanClearAllChecksums`

In each, the changelog resolves to `Total change sets: 0` against a freshly created container, so the `httpRequest` change never runs.